### PR TITLE
Add splay shots on button 2

### DIFF
--- a/C++/Main board C++/include/defaults.h
+++ b/C++/Main board C++/include/defaults.h
@@ -8,7 +8,7 @@ constexpr float gravTolerance = 10.0f; // degrees
 constexpr float dipTolerance = 10.0f;  // degrees
 constexpr bool anomalyDetection = true;
 constexpr float stabilityTolerance = 0.5f;    // degrees
-constexpr float quickShotStabilityTol = 3.0f; // degrees (wider for splay shots)
+constexpr float quickShotStabilityTol = 8.0f; // degrees (wider for splay shots)
 constexpr uint8_t stabilityBufferLength = 5;
 constexpr float emaAlphaStable = 0.05f;         // low alpha when stationary (max smoothing)
 constexpr float emaAlphaMoving = 0.6f;          // high alpha when moving (responsive)
@@ -52,7 +52,7 @@ constexpr uint32_t DISPLAY_REFRESH_MS = 250; // 4 Hz display updates
 constexpr uint32_t LOOP_INTERVAL_MS = 10;    // main loop pace
 constexpr float BATTERY_SHUTDOWN_PCT = 5.0f;
 constexpr uint32_t CALIB_HOLD_MS = 1000;    // 1s hold for menu
-constexpr uint32_t DISCO_HOLD_MS = 2000;    // 2s hold for disco toggle
+constexpr uint32_t DISCO_HOLD_MS = 1500;    // 2s hold for disco toggle
 constexpr uint32_t SNAKE_HOLD_MS = 5000;    // 5s hold for snake
 constexpr uint32_t MEASURE_GUARD_MS = 1500; // post-measure lockout
 } // namespace Timing

--- a/C++/Main board C++/include/defaults.h
+++ b/C++/Main board C++/include/defaults.h
@@ -33,6 +33,7 @@ constexpr uint32_t autoShutdownTimeout = 1800; // seconds (30 min)
 constexpr uint32_t laserTimeout = 120;         // seconds (2 min)
 constexpr bool laserWibble = true;             // blink laser on leg detect
 constexpr bool measureFromFront = false;       // false = Back (add offset), true = Front (raw laser)
+constexpr bool splaysEnabled = false;          // enable splay shots on button 2 short press
 constexpr uint8_t screenBrightness = 255;      // OLED contrast 0-255
 constexpr char bleName[] = "SAP6_Unicorn";
 constexpr uint8_t bleNameMaxLen = 20; // max chars for BLE name

--- a/C++/Main board C++/include/device_context.h
+++ b/C++/Main board C++/include/device_context.h
@@ -40,6 +40,7 @@ struct Config {
     uint32_t laserTimeout = Defaults::laserTimeout;
     bool laserWibble = Defaults::laserWibble;
     bool measureFromFront = Defaults::measureFromFront;
+    bool splaysEnabled = Defaults::splaysEnabled;
     uint8_t screenBrightness = Defaults::screenBrightness;
     char bleName[Defaults::bleNameMaxLen + 1] = {}; // initialized in constructor
 

--- a/C++/Main board C++/include/disco_manager.h
+++ b/C++/Main board C++/include/disco_manager.h
@@ -30,7 +30,7 @@ class DiscoManager {
     void turnOff();
 
     // ── Animated effects ────────────────────────────────────────────
-    void startDisco();
+    void turnOn();
     void setPurple(); // starts purple pulse
 
     // ── State queries ───────────────────────────────────────────────

--- a/C++/Main board C++/include/menu_manager.h
+++ b/C++/Main board C++/include/menu_manager.h
@@ -38,6 +38,7 @@ class MenuManager {
 
   private:
     void buildMenu();
+    void updateSplaysLabel();
 
     // Menu hierarchy (statically allocated, rebuilt on setting changes)
     FruityMenu _root;
@@ -53,7 +54,6 @@ class MenuManager {
     FruityMenu _measureFromSub;
     FruityMenu _reformatSub;
     FruityMenu _cartesianSub;
-    FruityMenu _splaySub;
 
     // Dynamic label buffers (updated in buildMenu)
     char _anomalyLabel[24];
@@ -98,7 +98,6 @@ class MenuManager {
     static void setMeasureFromFront(int);
     static void setMeasureFromBack(int);
     static void setCartesianTolerance(int value);
-    static void setSplaysOn(int);
-    static void setSplaysOff(int);
+    static void toggleSplays(int);
     static void exitMenu(int);
 };

--- a/C++/Main board C++/include/menu_manager.h
+++ b/C++/Main board C++/include/menu_manager.h
@@ -53,6 +53,7 @@ class MenuManager {
     FruityMenu _measureFromSub;
     FruityMenu _reformatSub;
     FruityMenu _cartesianSub;
+    FruityMenu _splaySub;
 
     // Dynamic label buffers (updated in buildMenu)
     char _anomalyLabel[24];
@@ -61,6 +62,7 @@ class MenuManager {
     char _brightnessLabel[24];
     char _measureFromLabel[24];
     char _cartesianLabel[28];
+    char _splaysLabel[20];
 
     // State
     Adafruit_SH1107 *_display = nullptr;
@@ -96,5 +98,7 @@ class MenuManager {
     static void setMeasureFromFront(int);
     static void setMeasureFromBack(int);
     static void setCartesianTolerance(int value);
+    static void setSplaysOn(int);
+    static void setSplaysOff(int);
     static void exitMenu(int);
 };

--- a/C++/Main board C++/src/config_manager.cpp
+++ b/C++/Main board C++/src/config_manager.cpp
@@ -221,6 +221,7 @@ bool ConfigManager::loadConfig(Config &cfg) {
     cfg.laserWibble = doc["laser_wibble"] | Defaults::laserWibble;
     cfg.measureFromFront = doc["measure_from_front"] | Defaults::measureFromFront;
     cfg.screenBrightness = doc["screen_brightness"] | (int)Defaults::screenBrightness;
+    cfg.splaysEnabled = doc["splays_enabled"] | Defaults::splaysEnabled;
 
     const char *rawName = doc["ble_name"] | Defaults::bleName;
     // Strip SAP6_ prefix if user included it — we always prepend it ourselves
@@ -266,6 +267,7 @@ bool ConfigManager::saveConfig(const Config &cfg) {
     doc["laser_wibble"] = cfg.laserWibble;
     doc["measure_from_front"] = cfg.measureFromFront;
     doc["screen_brightness"] = (int)cfg.screenBrightness;
+    doc["splays_enabled"] = cfg.splaysEnabled;
     // Save only the user portion — SAP6_ prefix is always auto-prepended on load
     const char *nameToSave = (strncmp(cfg.bleName, "SAP6_", 5) == 0) ? cfg.bleName + 5 : cfg.bleName;
     doc["ble_name"] = nameToSave;

--- a/C++/Main board C++/src/disco_manager.cpp
+++ b/C++/Main board C++/src/disco_manager.cpp
@@ -97,7 +97,7 @@ void DiscoManager::turnOff() { stopAll(); }
 
 // ── Animated effects ────────────────────────────────────────────────
 
-void DiscoManager::startDisco() {
+void DiscoManager::turnOn() {
     if (effect_ == DiscoEffect::DISCO) {
         return; // already running
     }

--- a/C++/Main board C++/src/main.cpp
+++ b/C++/Main board C++/src/main.cpp
@@ -3,6 +3,7 @@
 #include "calibration_mode.h"
 #include "config.h"
 #include "config_manager.h"
+#include "defaults.h"
 #include "device_context.h"
 #include "disco_manager.h"
 #include "display_manager.h"
@@ -19,6 +20,7 @@
 #include <Adafruit_TinyUSB.h>
 #include <Arduino.h>
 #include <Wire.h>
+#include <cstdint>
 
 // ── Embedded calibration data ──────────────────────────────────────
 // From Main board/calibration_dict.json — loaded at startup
@@ -154,9 +156,6 @@ static uint32_t discoHoldStart = 0;
 static bool discoHolding = false;
 static bool discoTriggered = false; // true once disco toggled during this hold
 
-// ── Measurement state ───────────────────────────────────────────────
-static bool measRedLedSet = false;
-
 // ── BLE state ───────────────────────────────────────────────────────
 static bool lastBleConnected = false;
 
@@ -167,7 +166,6 @@ static void onShutdownINT() { shutdownRequested = true; }
 // ── Forward declarations — init ────────────────────────────────────
 static void initPins();
 static void scanI2C();
-// initSensors() inlined into setup()
 static void initDisplay();
 static void initLaser();
 static void initBle();
@@ -209,10 +207,33 @@ static int32_t msc_write_cb(uint32_t lba, uint8_t *buffer, uint32_t bufsize) {
 
 static void msc_flush_cb() { s_mscFlash->syncBlocks(); }
 
+const bool REGULAR_SHOT = false;
+const bool QUCK_SHOT = true;
+
+void laserOn() {
+    if (!laserOk) {
+        return;
+    }
+    laser.setLaser(true);
+    ctx.laserEnabled = true;
+}
+
+void laserOff() {
+    if (!laserOk) {
+        return;
+    }
+    laser.setLaser(false);
+    ctx.laserEnabled = false;
+}
+
+
 // ═══════════════════════════════════════════════════════════════════
 // ── Setup ─────────────────────────────────────────────────────────
 // ═══════════════════════════════════════════════════════════════════
 void setup() {
+    // Init laser so it can be turned off immediately. There will still be a very brief flash.
+    initLaser();
+
     // Kill NeoPixel immediately to prevent green flash on boot
     pinMode(PIN_NEOPIXEL_POWER, OUTPUT);
     digitalWrite(PIN_NEOPIXEL_POWER, LOW);
@@ -353,7 +374,6 @@ void setup() {
     }
     Serial.println();
 
-    initLaser();
     initBle();
     initFlash();
 
@@ -413,13 +433,6 @@ void setup() {
         display.initScreen();
     }
 
-    // ── Startup: turn laser on with beep ───────────────────────────
-    if (laserOk) {
-        laser.setLaser(true);
-        laser.setBuzzer(true); // startup beep
-        laser.setBuzzer(false);
-        ctx.laserEnabled = true;
-    }
 
     // ── Low battery check on boot ────────────────────────────────
     // Skip if 0% — that means no LiPo connected (USB-only power)
@@ -573,10 +586,7 @@ void loop() {
         menuMgr.clearExitAction();
         if (dispOk) {
             Serial.println(F("Transitioning: menu → snake game"));
-            if (laserOk) {
-                laser.setLaser(false);
-            }
-            ctx.laserEnabled = false;
+            laserOff();
             snakeGame.begin(display.getDisplay(), buttons, disco);
         }
         delay(Timing::LOOP_INTERVAL_MS);
@@ -668,15 +678,6 @@ void loop() {
         Serial.println(F("Returning to normal mode"));
         display.updateMeasureFrom(ctx.config.measureFromFront);
         display.initScreen();
-        if (laserOk) {
-            laser.setLaser(true);
-            delay(25);
-            laser.setBuzzer(true);
-            delay(100);
-            laser.setBuzzer(false);
-            delay(25);
-        }
-        ctx.laserEnabled = true;
         ctx.lastActivityTime = millis();
         delay(Timing::LOOP_INTERVAL_MS);
         return;
@@ -707,15 +708,7 @@ void loop() {
                                ctx.config.stabilityBufferLength, Defaults::emaJumpThreshold);
             }
             display.initScreen();
-            if (laserOk) {
-                laser.setLaser(true);
-                delay(25);
-                laser.setBuzzer(true);
-                delay(100);
-                laser.setBuzzer(false);
-                delay(25);
-            }
-            ctx.laserEnabled = true;
+            laserOn();
             ctx.lastActivityTime = millis();
         }
         delay(Timing::LOOP_INTERVAL_MS);
@@ -806,205 +799,127 @@ static void readSensorsUpdate(uint32_t now) {
     }
 }
 
-// ── Button event handling ───────────────────────────────────────
-static void pollButtons(uint32_t now) {
-    // ── Button 1 (MEASURE) — take measurement or wake laser ──
-    if (buttons.wasPressed(Button::MEASURE)) {
-        ctx.purpleLatched = false;
-        ctx.lastActivityTime = now;
+static void startDisco() {
+    disco.turnOn();
+    ctx.discoOn = true;
+    laser.setLaser(false);
+    ctx.laserEnabled = false;
+    Serial.println(F("DISCO: on"));
+}
 
-        if (ctx.displayFrozen && !ctx.laserEnabled) {
-            // Leg complete — laser off, just unfreeze + turn laser on
-            ctx.displayFrozen = false;
-            if (laserOk) {
-                laser.setLaser(true);
-            }
-            ctx.laserEnabled = true;
-            lastDistance = 0;
-            disco.turnOff();
-            Serial.println(F("MEASURE: unfreezing after leg, live readings"));
-        } else if (ctx.displayFrozen && ctx.laserEnabled) {
-            // Normal shot freeze — laser is on, go straight to measurement
-            ctx.displayFrozen = false;
-            ctx.currentState = SystemState::TAKING_MEASUREMENT;
-            ctx.measurementTaken = false;
-            measRedLedSet = false;
-            lastDistance = 0;
-            Serial.println(F("MEASURE: taking measurement (from frozen)"));
-        } else if (ctx.laserEnabled) {
-            // Laser already on, live display — take measurement
-            ctx.currentState = SystemState::TAKING_MEASUREMENT;
-            ctx.measurementTaken = false;
-            measRedLedSet = false;
-            lastDistance = 0;
-            Serial.println(F("MEASURE: taking measurement"));
-        } else if (ctx.currentState == SystemState::IDLE) {
-            // Laser was off (timeout etc) — beep + turn on
-            if (laserOk) {
-                laser.setBuzzer(true);
-                delay(25);
-                laser.setLaser(true);
-                delay(200);
-                laser.setBuzzer(false);
-                delay(25);
-            }
-            ctx.laserEnabled = true;
-            lastDistance = 0;
-            Serial.println(F("MEASURE: laser re-enabled"));
-        } else {
-            Serial.println(F("MEASURE: system busy, ignored"));
-            ctx.currentState = SystemState::IDLE;
-        }
+static void stopDisco() {
+    disco.turnOff();
+    ctx.discoOn = false;
+    laser.setLaser(false);
+    ctx.laserEnabled = false;
+    Serial.println(F("DISCO: off"));
+}
+
+
+static bool heldLongEnoughForDisco(uint32_t now, uint32_t start) {
+    return now - start >= Timing::DISCO_HOLD_MS;
+}
+
+
+static void prepareForShot() {
+    // Setup laser
+    laserOn();
+    lastDistance = 0;
+
+    ctx.displayFrozen = false;
+    disco.turnOff();
+    Serial.println(F("MEASURE: getting ready for a shot"));
+}
+
+// Call after prepare for shot
+static void startShot(bool isQuickShot) {
+    ctx.quickShot = isQuickShot;
+    ctx.displayFrozen = false;
+    ctx.currentState = SystemState::TAKING_MEASUREMENT;
+    ctx.measurementTaken = false;
+    lastDistance = 0;
+    Serial.println(F("MEASURE: taking measurement"));
+
+    if (!ctx.purpleLatched) {
+        disco.setRed();
     }
 
-    // ── Button 2 (DISCO) — short press: same as MEASURE (full accuracy), hold 2s: toggle disco ──
+    laser.singleBeep();
+}
+
+
+// ── Button event handling ───────────────────────────────────────
+static void pollButtons(uint32_t now) {
+    // Button 1 (MEASURE)
+    // Take measurement or wake laser
+    if (buttons.wasPressed(Button::MEASURE)) {
+        ctx.lastActivityTime = now;
+        ctx.purpleLatched = false;
+
+        if (ctx.laserEnabled) {
+            startShot(REGULAR_SHOT);
+        } else {
+            prepareForShot();
+            delay(20);
+        }
+        return;
+    }
+
+    // Button 2 (DISCO)
+    // Long press to toggle disco, short press for splay/quick shot
     if (buttons.isPressed(Button::DISCO)) {
         ctx.lastActivityTime = now;
         if (!discoHolding) {
-            discoHoldStart = now;
             discoHolding = true;
             discoTriggered = false;
+            discoHoldStart = now;
         } else if (!discoTriggered) {
-            uint32_t held = now - discoHoldStart;
-            if (held >= Timing::DISCO_HOLD_MS) {
+            if (heldLongEnoughForDisco(now, discoHoldStart)) {
                 discoTriggered = true;
-                if (ctx.discoOn) {
-                    disco.turnOff();
-                    ctx.discoOn = false;
-                    if (laserOk) {
-                        laser.setLaser(false);
-                    }
-                    ctx.laserEnabled = false;
-                    Serial.println(F("DISCO: off"));
-                } else {
-                    disco.startDisco();
-                    ctx.discoOn = true;
-                    if (laserOk) {
-                        laser.setLaser(false);
-                    }
-                    ctx.laserEnabled = false;
-                    Serial.println(F("DISCO: on"));
-                }
+                ctx.discoOn ? stopDisco() : startDisco();
             }
         }
-    } else {
-        // Released — short press = same as MEASURE
-        if (discoHolding && !discoTriggered) {
-            ctx.purpleLatched = false;
+        return;
+    } else { // Short press -> splay shot
+        if (discoHolding) {
+            discoHolding = false;
 
-            if (ctx.displayFrozen && !ctx.laserEnabled) {
-                ctx.displayFrozen = false;
-                if (laserOk) {
-                    laser.setLaser(true);
-                }
-                ctx.laserEnabled = true;
-                lastDistance = 0;
-                disco.turnOff();
-                Serial.println(F("MEASURE(B2): unfreezing after leg, live readings"));
-            } else if (ctx.displayFrozen && ctx.laserEnabled) {
-                ctx.displayFrozen = false;
-                ctx.currentState = SystemState::TAKING_MEASUREMENT;
-                ctx.measurementTaken = false;
-                measRedLedSet = false;
-                lastDistance = 0;
-                Serial.println(F("MEASURE(B2): taking measurement (from frozen)"));
-            } else if (ctx.laserEnabled) {
-                ctx.currentState = SystemState::TAKING_MEASUREMENT;
-                ctx.measurementTaken = false;
-                measRedLedSet = false;
-                lastDistance = 0;
-                Serial.println(F("MEASURE(B2): taking measurement"));
-            } else if (ctx.currentState == SystemState::IDLE) {
-                if (laserOk) {
-                    laser.setBuzzer(true);
-                    delay(25);
-                    laser.setLaser(true);
-                    delay(200);
-                    laser.setBuzzer(false);
-                    delay(25);
-                }
-                ctx.laserEnabled = true;
-                lastDistance = 0;
-                Serial.println(F("MEASURE(B2): laser re-enabled"));
+            if (discoTriggered) {
+                discoTriggered = false;
             } else {
-                Serial.println(F("MEASURE(B2): system busy, ignored"));
-                ctx.currentState = SystemState::IDLE;
+                ctx.laserEnabled ? startShot(QUCK_SHOT) : prepareForShot();
             }
+            return;
         }
-        discoHolding = false;
     }
 
-    // ── Button 3 (CALIB) — short press: enter menu mode ──
+
+    // Button 3 (MENU)
     if (buttons.wasPressed(Button::CALIB) && ctx.currentState == SystemState::IDLE) {
         ctx.lastActivityTime = now;
         Serial.println(F("CALIB pressed — entering menu mode"));
-        if (laserOk) {
-            laser.setLaser(false);
-        }
+        laser.setLaser(false);
         ctx.laserEnabled = false;
         disco.turnOff();
         ctx.discoOn = false;
         menuMgr.begin(display.getDisplay(), ctx, configMgr);
-        return; // skip rest of pollButtons
+        return;
     }
 
-    // ── Button 4 (SHUTDOWN) — power off with post-measurement guard ──
     // Button 4 (SHUTDOWN) handled via interrupt at top of loop()
-
-    // ── Fire button (FIRE) — same as MEASURE (trigger button) ──
-    if (buttons.wasPressed(Button::FIRE)) {
-        ctx.purpleLatched = false;
-        ctx.lastActivityTime = now;
-
-        if (ctx.displayFrozen && !ctx.laserEnabled) {
-            // Leg complete — laser off, just unfreeze + turn laser on
-            ctx.displayFrozen = false;
-            if (laserOk) {
-                laser.setLaser(true);
-            }
-            ctx.laserEnabled = true;
-            lastDistance = 0;
-            disco.turnOff();
-            Serial.println(F("FIRE: unfreezing after leg, live readings"));
-        } else if (ctx.displayFrozen && ctx.laserEnabled) {
-            // Normal shot freeze — laser is on, go straight to measurement
-            ctx.displayFrozen = false;
-            ctx.currentState = SystemState::TAKING_MEASUREMENT;
-            ctx.measurementTaken = false;
-            measRedLedSet = false;
-            lastDistance = 0;
-            Serial.println(F("FIRE: taking measurement (from frozen)"));
-        } else if (ctx.laserEnabled) {
-            // Laser already on, live display — take measurement
-            ctx.currentState = SystemState::TAKING_MEASUREMENT;
-            ctx.measurementTaken = false;
-            measRedLedSet = false;
-            lastDistance = 0;
-            Serial.println(F("FIRE: taking measurement"));
-        } else if (ctx.currentState == SystemState::IDLE) {
-            if (laserOk) {
-                laser.setBuzzer(true);
-                delay(25);
-                laser.setLaser(true);
-                delay(200);
-                laser.setBuzzer(false);
-                delay(25);
-            }
-            ctx.laserEnabled = true;
-            lastDistance = 0;
-            Serial.println(F("FIRE: laser re-enabled"));
-        }
-    }
 }
+
 
 // ── Measurement workflow ────────────────────────────────────────
 static void pollMeasurement(uint32_t now) {
     if (ctx.currentState != SystemState::TAKING_MEASUREMENT) {
         return;
     }
+
     if (ctx.measurementTaken) {
         return;
     }
+
     if (!calOk || !magOk || !imuOk || !laserOk) {
         Serial.println(F("MEAS: sensors not ready"));
         ctx.quickShot = false;
@@ -1012,27 +927,11 @@ static void pollMeasurement(uint32_t now) {
         return;
     }
 
-    // Set red LED once on entry
-    if (!measRedLedSet) {
-        if (!ctx.purpleLatched) {
-            disco.setRed();
-        }
-        // Ensure laser is on (only sends UART if it was off)
-        if (!ctx.laserEnabled) {
-            laser.setLaser(true);
-            delay(100);
-            ctx.laserEnabled = true;
-        }
-        // Entry click buzzer
-        laser.singleBeep();
-        measRedLedSet = true;
-    }
+    // const ILegChecker &stabChecker = ctx.quickShot ? ctx.quickShotStabilityChecker : ctx.stabilityChecker;
+    const ILegChecker &stabChecker = ctx.stabilityChecker;
 
-    const ILegChecker &stabChecker = ctx.quickShot
-                                         ? static_cast<const ILegChecker &>(ctx.quickShotStabilityChecker)
-                                         : ctx.stabilityChecker;
-
-    if (!sensorMgr.isStable(stabChecker)) {
+    // No stability checking for quick shots. (In Beta)
+    if (!ctx.quickShot && !sensorMgr.isStable(stabChecker)) {
         static uint32_t lastStabDbg = 0;
         uint32_t n = millis();
         if (n - lastStabDbg > 1000) {
@@ -1044,7 +943,8 @@ static void pollMeasurement(uint32_t now) {
         }
         return;
     }
-    Serial.println(F("MEAS: stable — measuring"));
+
+    Serial.println(F("MEAS: taking measurement"));
 
     // ── Stable — take measurement ────────────────────────────
     ctx.readings.azimuth = sensorMgr.getAzimuth();
@@ -1055,7 +955,7 @@ static void pollMeasurement(uint32_t now) {
     while (Serial1.available()) {
         Serial1.read();
     }
-    delay(50); // let the UART line settle
+    delay(30); // let the UART line settle
 
     // Take laser distance
     Serial.println(F("MEAS: sending measure cmd..."));
@@ -1065,6 +965,7 @@ static void pollMeasurement(uint32_t now) {
     Serial.print(LaserEgismos::errorString(lErr));
     Serial.print(F(" mm="));
     Serial.println(distMm);
+
     if (lErr != LaserError::OK) {
         Serial.print(F("MEAS: laser error: "));
         Serial.println(LaserEgismos::errorString(lErr));
@@ -1138,17 +1039,6 @@ static void pollMeasurement(uint32_t now) {
     dispInc = ctx.readings.inclination;
     ctx.displayFrozen = true;
 
-    // Laser off after shot — user presses MEASURE/FIRE to re-enable
-    if (laserOk) {
-        laser.setLaser(false);
-    }
-    ctx.laserEnabled = false;
-    if (!ctx.purpleLatched) {
-        disco.turnOff();
-    }
-
-    ctx.quickShot = false;
-    ctx.currentState = SystemState::IDLE;
 
     Serial.print(F("MEAS OK: AZ="));
     Serial.print(ctx.readings.azimuth, 1);
@@ -1156,6 +1046,20 @@ static void pollMeasurement(uint32_t now) {
     Serial.print(ctx.readings.inclination, 1);
     Serial.print(F(" DIST="));
     Serial.println(ctx.readings.distance, 2);
+
+    ctx.currentState = SystemState::IDLE;
+
+    if (!ctx.purpleLatched) {
+        disco.turnOff();
+    }
+
+    // If doing quick shots, prepare again immediately.
+    if (ctx.quickShot) {
+        prepareForShot();
+    } else {
+        laserOff();
+    }
+    ctx.quickShot = false;
 }
 
 // ── Handle successful measurement ───────────────────────────────
@@ -1172,6 +1076,7 @@ static void handleMeasurementSuccess() {
     Serial.println(bleOk);
     Serial.flush();
     delay(50);
+
     // Send via BLE or queue
     if (ctx.bleConnected && bleOk) {
         Serial.println(F("  HS:2a ble send"));
@@ -1192,6 +1097,9 @@ static void handleMeasurementSuccess() {
     if (ctx.quickShot) {
         Serial.println(F("  HS:3 quick shot — skipping leg buf"));
         ctx.measurementTaken = false;
+        laser.singleBeep();
+        // If doing quick shots, prepare again immediately
+        prepareForShot();
         return;
     }
 
@@ -1350,24 +1258,17 @@ static void pollBLECommands(uint32_t now) {
         break;
 
     case BleCommand::TAKE_SHOT:
-        ctx.currentState = SystemState::TAKING_MEASUREMENT;
-        ctx.measurementTaken = false;
-        measRedLedSet = false;
+        prepareForShot();
+        startShot(REGULAR_SHOT);
         ctx.lastActivityTime = now;
         break;
 
     case BleCommand::LASER_ON:
-        if (laserOk) {
-            laser.setLaser(true);
-        }
-        ctx.laserEnabled = true;
+        laserOn();
         break;
 
     case BleCommand::LASER_OFF:
-        if (laserOk) {
-            laser.setLaser(false);
-        }
-        ctx.laserEnabled = false;
+        laserOff();
         break;
 
     case BleCommand::DEVICE_OFF:
@@ -1376,10 +1277,7 @@ static void pollBLECommands(uint32_t now) {
 
     case BleCommand::START_CAL:
         Serial.println(F("BLE: entering menu mode"));
-        if (laserOk) {
-            laser.setLaser(false);
-        }
-        ctx.laserEnabled = false;
+        laserOff();
         disco.turnOff();
         ctx.discoOn = false;
         menuMgr.begin(display.getDisplay(), ctx, configMgr);
@@ -1613,6 +1511,7 @@ static void resetLaser() {
 
 static void doShutdown() {
     Serial.println(F(">>> SHUTDOWN"));
+    laserOff();
     // Flush any unsaved readings to flash before power dies
     if (flashOk && configMgr.hasPendingToSync()) {
         configMgr.syncPendingToFlash();
@@ -1727,7 +1626,7 @@ static void initLaser() {
     Serial.print(F("Laser:       "));
     Serial.println(laserOk ? F("OK (Egismos @ 9600)") : F("FAILED"));
 
-    // Buzzer disabled for debugging — skip init command
+    laserOff();
 
     Serial.println();
 }

--- a/C++/Main board C++/src/main.cpp
+++ b/C++/Main board C++/src/main.cpp
@@ -189,6 +189,7 @@ static void checkLaserTimeout(uint32_t now);
 static void updateDisplay(uint32_t now);
 
 // ── Forward declarations — helpers ──────────────────────────────────
+static void showSplaysDisabledToast();
 static void handleMeasurementSuccess();
 static void alertError(const char *errCode);
 static void resetLaser();
@@ -802,6 +803,20 @@ static void readSensorsUpdate(uint32_t now) {
     }
 }
 
+static void showSplaysDisabledToast() {
+    if (dispOk) {
+        auto &d = display.getDisplay();
+        d.clearDisplay();
+        d.setTextColor(SH110X_WHITE);
+        d.setTextSize(2);
+        d.setCursor(0, 44);
+        d.println(F("Splays not"));
+        d.println(F("enabled"));
+        d.display();
+    }
+    splaysToastTime = millis();
+}
+
 static void startDisco() {
     disco.turnOn();
     ctx.discoOn = true;
@@ -893,7 +908,8 @@ static void pollButtons(uint32_t now) {
                 if (ctx.config.splaysEnabled) {
                     ctx.laserEnabled ? startShot(QUCK_SHOT) : prepareForShot();
                 } else {
-                    splaysToastTime = millis();
+                    showSplaysDisabledToast();
+                    laser.failureBeep();
                 }
             }
             return;
@@ -1430,9 +1446,11 @@ static void updateDisplay(uint32_t now) {
         return;
     }
 
-    // Show "Splays not enabled" toast for 2s, suppressing normal refresh
+    // Show "Splays not enabled" toast for 2s, suppressing normal refresh.
+    // Use millis() not now — now is stale from the top of loop() and may
+    // predate splaysToastTime (set after a blocking beep), causing underflow.
     if (splaysToastTime != 0) {
-        if (now - splaysToastTime < 2000) {
+        if (millis() - splaysToastTime < 1200) {
             if (now - lastDisplayRefresh >= Timing::DISPLAY_REFRESH_MS) {
                 lastDisplayRefresh = now;
                 auto &d = display.getDisplay();

--- a/C++/Main board C++/src/main.cpp
+++ b/C++/Main board C++/src/main.cpp
@@ -156,6 +156,9 @@ static uint32_t discoHoldStart = 0;
 static bool discoHolding = false;
 static bool discoTriggered = false; // true once disco toggled during this hold
 
+// ── Toast notifications ─────────────────────────────────────────────
+static uint32_t splaysToastTime = 0;
+
 // ── BLE state ───────────────────────────────────────────────────────
 static bool lastBleConnected = false;
 
@@ -887,7 +890,11 @@ static void pollButtons(uint32_t now) {
             if (discoTriggered) {
                 discoTriggered = false;
             } else {
-                ctx.laserEnabled ? startShot(QUCK_SHOT) : prepareForShot();
+                if (ctx.config.splaysEnabled) {
+                    ctx.laserEnabled ? startShot(QUCK_SHOT) : prepareForShot();
+                } else {
+                    splaysToastTime = millis();
+                }
             }
             return;
         }
@@ -1422,6 +1429,27 @@ static void updateDisplay(uint32_t now) {
     if (!dispOk) {
         return;
     }
+
+    // Show "Splays not enabled" toast for 2s, suppressing normal refresh
+    if (splaysToastTime != 0) {
+        if (now - splaysToastTime < 2000) {
+            if (now - lastDisplayRefresh >= Timing::DISPLAY_REFRESH_MS) {
+                lastDisplayRefresh = now;
+                auto &d = display.getDisplay();
+                d.clearDisplay();
+                d.setTextColor(SH110X_WHITE);
+                d.setTextSize(2);
+                d.setCursor(0, 44);
+                d.println(F("Splays not"));
+                d.println(F("enabled"));
+                d.display();
+            }
+            return;
+        } else {
+            splaysToastTime = 0;
+        }
+    }
+
     if (now - lastDisplayRefresh < Timing::DISPLAY_REFRESH_MS) {
         return;
     }

--- a/C++/Main board C++/src/menu_manager.cpp
+++ b/C++/Main board C++/src/menu_manager.cpp
@@ -113,8 +113,7 @@ void MenuManager::buildMenu() {
 
     snprintf(_cartesianLabel, sizeof(_cartesianLabel), "Leg tol: %dcm", (int)_ctx->config.cartesianTolerance);
 
-    snprintf(_splaysLabel, sizeof(_splaysLabel), "Splays: %s",
-             _ctx->config.splaysEnabled ? "On" : "Off");
+    updateSplaysLabel();
 
     snprintf(_measureFromLabel, sizeof(_measureFromLabel), "Measure from: %s",
              _ctx->config.measureFromFront ? "Front" : "Back");
@@ -132,7 +131,6 @@ void MenuManager::buildMenu() {
     _measureFromSub.init(*_display, _measureFromLabel);
     _reformatSub.init(*_display, "Reformat (via USB)");
     _cartesianSub.init(*_display, _cartesianLabel);
-    _splaySub.init(*_display, _splaysLabel);
 
     // ── Root menu items ────────────────────────────────
     _root.addAction("Exit", exitMenu);
@@ -209,7 +207,7 @@ void MenuManager::buildMenu() {
     _settingsSub.addSubmenu(_shutdownLabel, &_shutdownSub);
     _settingsSub.addSubmenu(_brightnessLabel, &_brightnessSub);
     _settingsSub.addSubmenu(_cartesianLabel, &_cartesianSub);
-    _settingsSub.addSubmenu(_splaysLabel, &_splaySub);
+    _settingsSub.addAction(_splaysLabel, toggleSplays);
     _settingsSub.addAction("Edit Settings File", enterUsbDrive);
     _settingsSub.addSubmenu("Reformat (via USB)", &_reformatSub);
     _settingsSub.addAction("<- Back", goToRoot);
@@ -227,11 +225,6 @@ void MenuManager::buildMenu() {
     _cartesianSub.addAction("25 cm", setCartesianTolerance, 25);
     _cartesianSub.addAction("30 cm", setCartesianTolerance, 30);
     _cartesianSub.addAction("<- Back", goToSettings);
-
-    // ── Splays submenu ──────────────────────────────────────────────────
-    _splaySub.addAction("On", setSplaysOn);
-    _splaySub.addAction("Off", setSplaysOff);
-    _splaySub.addAction("<- Back", goToSettings);
 
     // ── Reformat submenu (recovery — opens USB mode to format on a PC) ──
     _reformatSub.addAction("No", goToSettings);
@@ -470,24 +463,20 @@ void MenuManager::setCartesianTolerance(int value) {
     s_instance->buildMenu();
 }
 
-void MenuManager::setSplaysOn(int) {
-    if (!s_instance) {
-        return;
-    }
-    s_instance->_ctx->config.splaysEnabled = true;
-    s_instance->_cfgMgr->saveConfig(s_instance->_ctx->config);
-    Serial.println(F("Menu: splays ON"));
-    s_instance->buildMenu();
+void MenuManager::updateSplaysLabel() {
+    snprintf(_splaysLabel, sizeof(_splaysLabel), "Splays: %s",
+             _ctx->config.splaysEnabled ? "On" : "Off");
 }
 
-void MenuManager::setSplaysOff(int) {
+void MenuManager::toggleSplays(int) {
     if (!s_instance) {
         return;
     }
-    s_instance->_ctx->config.splaysEnabled = false;
+    s_instance->_ctx->config.splaysEnabled = !s_instance->_ctx->config.splaysEnabled;
     s_instance->_cfgMgr->saveConfig(s_instance->_ctx->config);
-    Serial.println(F("Menu: splays OFF"));
-    s_instance->buildMenu();
+    Serial.print(F("Menu: splays "));
+    Serial.println(s_instance->_ctx->config.splaysEnabled ? F("ON") : F("OFF"));
+    s_instance->updateSplaysLabel();
 }
 
 void MenuManager::exitMenu(int) {

--- a/C++/Main board C++/src/menu_manager.cpp
+++ b/C++/Main board C++/src/menu_manager.cpp
@@ -113,6 +113,9 @@ void MenuManager::buildMenu() {
 
     snprintf(_cartesianLabel, sizeof(_cartesianLabel), "Leg tol: %dcm", (int)_ctx->config.cartesianTolerance);
 
+    snprintf(_splaysLabel, sizeof(_splaysLabel), "Splays: %s",
+             _ctx->config.splaysEnabled ? "On" : "Off");
+
     snprintf(_measureFromLabel, sizeof(_measureFromLabel), "Measure from: %s",
              _ctx->config.measureFromFront ? "Front" : "Back");
 
@@ -129,6 +132,7 @@ void MenuManager::buildMenu() {
     _measureFromSub.init(*_display, _measureFromLabel);
     _reformatSub.init(*_display, "Reformat (via USB)");
     _cartesianSub.init(*_display, _cartesianLabel);
+    _splaySub.init(*_display, _splaysLabel);
 
     // ── Root menu items ────────────────────────────────
     _root.addAction("Exit", exitMenu);
@@ -205,6 +209,7 @@ void MenuManager::buildMenu() {
     _settingsSub.addSubmenu(_shutdownLabel, &_shutdownSub);
     _settingsSub.addSubmenu(_brightnessLabel, &_brightnessSub);
     _settingsSub.addSubmenu(_cartesianLabel, &_cartesianSub);
+    _settingsSub.addSubmenu(_splaysLabel, &_splaySub);
     _settingsSub.addAction("Edit Settings File", enterUsbDrive);
     _settingsSub.addSubmenu("Reformat (via USB)", &_reformatSub);
     _settingsSub.addAction("<- Back", goToRoot);
@@ -222,6 +227,11 @@ void MenuManager::buildMenu() {
     _cartesianSub.addAction("25 cm", setCartesianTolerance, 25);
     _cartesianSub.addAction("30 cm", setCartesianTolerance, 30);
     _cartesianSub.addAction("<- Back", goToSettings);
+
+    // ── Splays submenu ──────────────────────────────────────────────────
+    _splaySub.addAction("On", setSplaysOn);
+    _splaySub.addAction("Off", setSplaysOff);
+    _splaySub.addAction("<- Back", goToSettings);
 
     // ── Reformat submenu (recovery — opens USB mode to format on a PC) ──
     _reformatSub.addAction("No", goToSettings);
@@ -457,6 +467,26 @@ void MenuManager::setCartesianTolerance(int value) {
     Serial.print(F("Menu: cartesian tolerance = "));
     Serial.print(value);
     Serial.println(F(" cm"));
+    s_instance->buildMenu();
+}
+
+void MenuManager::setSplaysOn(int) {
+    if (!s_instance) {
+        return;
+    }
+    s_instance->_ctx->config.splaysEnabled = true;
+    s_instance->_cfgMgr->saveConfig(s_instance->_ctx->config);
+    Serial.println(F("Menu: splays ON"));
+    s_instance->buildMenu();
+}
+
+void MenuManager::setSplaysOff(int) {
+    if (!s_instance) {
+        return;
+    }
+    s_instance->_ctx->config.splaysEnabled = false;
+    s_instance->_cfgMgr->saveConfig(s_instance->_ctx->config);
+    Serial.println(F("Menu: splays OFF"));
     s_instance->buildMenu();
 }
 


### PR DESCRIPTION
Fix #19 

- Stability checking is disabled for splays so they are much quicker to take.
- Splays do not count towards legs. This is true on the DiscoX itself -- a triple beep will never be triggered by splays. 3 near-identical splay shots may trigger a leg on a synced phone.
- Laser stays on after a splay to allow for quick consecutive splay shots.
- Splay shots are disabled by default to avoid confusion. They can be enabled from the settings menu.

Also:
- Significantly tidies up button polling code.
- Turns the laser off on device start. This can be surprising and the laser may be pointed at people. There is still a very brief flash of the laser because it is powered on slightly before the initialisation code takes place.